### PR TITLE
fix(#4): use = instead of . for padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import {
   isBase64, isUrlSafeBase64
 } from 'url-safe-base64'
 const safe = encode('A/B+C==')
-// > 'A-B_C..'
+// > 'A-B_C=='
 trim(safe)
 // > 'A-B_C'
 const base64 = decode(safe)

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.trim = exports.isUrlSafeBase64 = exports.isBase64 = exports.encode = exports.decode = void 0;
-
 /**
  * @module url-safe-base64
  * @license UNLICENSE
@@ -28,76 +27,67 @@ exports.trim = exports.isUrlSafeBase64 = exports.isBase64 = exports.encode = exp
  * isUrlSafeBase64(safe)
  * // > true
  */
+
 var ENC = {
   '+': '-',
-  '/': '_',
-  '=': '.'
+  '/': '_'
 };
 var DEC = {
   '-': '+',
   _: '/',
   '.': '='
 };
+
 /**
  * encode base64 string url safe
  * @param {String} base64 - base64 encoded string
  * @return {String} url-safe-base64 encoded
  */
-
 var encode = function encode(base64) {
-  return base64.replace(/[+/=]/g, function (m) {
+  return base64.replace(/[+/]/g, function (m) {
     return ENC[m];
   });
 };
+
 /**
  * decode url-safe-base64 string to base64
  * @param {String} safe - url-safe-base64 string
  * @return {String} base64 encoded
  */
-
-
 exports.encode = encode;
-
 var decode = function decode(safe) {
   return safe.replace(/[-_.]/g, function (m) {
     return DEC[m];
   });
 };
+
 /**
  * trim padding - `window.atob` might handle trimmed strings, e.g. in Chrome@57, Firefox@52
  * @param {String} string - base64 or url-safe-base64 string
  * @return {String} string with padding chars removed
  */
-
-
 exports.decode = decode;
-
 var trim = function trim(string) {
   return string.replace(/[.=]{1,2}$/, '');
 };
+
 /**
  * checks if `string` is base64 encoded
  * @param {String} string
  * @return {Boolean} true if base64 encoded
  */
-
-
 exports.trim = trim;
-
 var isBase64 = function isBase64(string) {
   return /^[A-Za-z0-9+/]*[=]{0,2}$/.test(string);
 };
+
 /**
  * checks if `string` is url-safe-base64 encoded
  * @param {String} string
  * @return {Boolean} true if url-safe-base64 encoded
  */
-
-
 exports.isBase64 = isBase64;
-
 var isUrlSafeBase64 = function isUrlSafeBase64(string) {
-  return /^[A-Za-z0-9_-]*[.]{0,2}$/.test(string);
+  return /^[A-Za-z0-9_-]*[.=]{0,2}$/.test(string);
 };
-
 exports.isUrlSafeBase64 = isUrlSafeBase64;

--- a/package.json
+++ b/package.json
@@ -50,16 +50,16 @@
   "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.19.3",
-    "@babel/core": "^7.19.3",
-    "@babel/preset-env": "^7.19.3",
+    "@babel/core": "^7.20.5",
+    "@babel/preset-env": "^7.20.2",
     "@babel/register": "^7.18.9",
-    "eslint": "^8.24.0",
+    "eslint": "^8.29.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-n": "^15.3.0",
-    "eslint-plugin-promise": "^6.0.1",
-    "mocha": "^10.0.0",
+    "eslint-plugin-n": "^15.6.0",
+    "eslint-plugin-promise": "^6.1.1",
+    "mocha": "^10.2.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.8.4"
+    "typescript": "^4.9.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-safe-base64",
-  "version": "1.2.0",
+  "version": "1.3.0-0",
   "description": "url safe base64 en- and decoding",
   "keywords": [
     "base64",

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,7 @@
 
 const ENC = {
   '+': '-',
-  '/': '_',
-  '=': '.'
+  '/': '_'
 }
 const DEC = {
   '-': '+',
@@ -39,7 +38,7 @@ const DEC = {
  * @return {String} url-safe-base64 encoded
  */
 export const encode = (base64) => {
-  return base64.replace(/[+/=]/g, (m) => ENC[m])
+  return base64.replace(/[+/]/g, (m) => ENC[m])
 }
 
 /**
@@ -72,4 +71,4 @@ export const isBase64 = (string) => /^[A-Za-z0-9+/]*[=]{0,2}$/.test(string)
  * @param {String} string
  * @return {Boolean} true if url-safe-base64 encoded
  */
-export const isUrlSafeBase64 = (string) => /^[A-Za-z0-9_-]*[.]{0,2}$/.test(string)
+export const isUrlSafeBase64 = (string) => /^[A-Za-z0-9_-]*[.=]{0,2}$/.test(string)

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,9 @@ import assert from 'assert'
 import { encode, decode, trim, isBase64, isUrlSafeBase64 } from '..'
 
 const base64chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='
-const urlSafeChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.'
+const urlSafeChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='
+// non standard padding uses `.`
+const urlSafeCharsAlt = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.'
 
 describe('url-safe', function () {
   const b64 = [base64chars, base64chars, base64chars].join()
@@ -48,6 +50,10 @@ describe('url-safe', function () {
       const res = isUrlSafeBase64(urlSafeChars)
       assert.strictEqual(res, true)
     })
+    it('urlSafeCharsAlt', function () {
+      const res = isUrlSafeBase64(urlSafeCharsAlt)
+      assert.strictEqual(res, true)
+    })
     it('b64', function () {
       const res = isUrlSafeBase64(b64)
       assert.strictEqual(res, false)
@@ -63,18 +69,7 @@ describe('url-safe', function () {
       ['A', 'A'],
       ['A=', 'A'],
       ['A==', 'A'],
-      ['A===', 'A=']
-    ].forEach((test) => {
-      it(test[0], function () {
-        const res = trim(test[0])
-        assert.strictEqual(res, test[1])
-      })
-    })
-  })
-
-  describe('should trim padding from url-safe-base64', function () {
-    ;[
-      ['A', 'A'],
+      ['A===', 'A='],
       ['A.', 'A'],
       ['A..', 'A'],
       ['A...', 'A.']


### PR DESCRIPTION
Fixes Issue #4

For standard compliance with RFC4648 the padding character was changed from the non-standard "." to the standard "=" character.

Decoding now allows for both padding-chars "." and "=".